### PR TITLE
Clippy fixes and small improvements

### DIFF
--- a/.github/workflows/analyzers.yml
+++ b/.github/workflows/analyzers.yml
@@ -14,18 +14,18 @@ jobs:
         run: sudo apt-get install clang-format-12
       - name: Check clang-format
         run: ci/clang-format-check.sh
-  
+
   cmake_format:
     runs-on: ubuntu-20.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 #v3.1.0
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 #v4.3.0
-        with: 
+        with:
           python-version: '3.x'
           architecture: 'x64'
       - uses: BSFishy/pip-action@8f2d471d809dc20b6ada98c91910b6ae6243f318
-        with: 
+        with:
           packages: |
             cmake-format
       - name: Check cmake-format
@@ -38,10 +38,25 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 #v3.1.0
       - name: Run code-inspector
         run: ci/code-inspector-check.sh
-  
+
   cargo_fmt:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
       - name: Run cargo fmt
         run: ci/cargo-fmt-check.sh
+
+  cargo_clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+          override: true
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features
+          name: Clippy Output

--- a/rust/core/src/account.rs
+++ b/rust/core/src/account.rs
@@ -13,7 +13,7 @@ impl Account {
         let mut number = U512::from_big_endian(&self.0);
         let check = U512::from_little_endian(&self.account_checksum());
         number <<= 40;
-        number = number | check;
+        number |= check;
 
         let mut result = String::with_capacity(65);
 

--- a/rust/core/src/amount.rs
+++ b/rust/core/src/amount.rs
@@ -2,7 +2,7 @@ use crate::utils::{Deserialize, Serialize, Stream};
 use anyhow::Result;
 use once_cell::sync::Lazy;
 
-#[derive(Clone, Copy, PartialEq, Eq, Default, Debug, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, Default, Debug)]
 pub struct Amount {
     raw: u128, // native endian!
 }
@@ -161,6 +161,12 @@ impl std::ops::Sub for Amount {
 impl std::cmp::PartialOrd for Amount {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         self.raw.partial_cmp(&other.raw)
+    }
+}
+
+impl std::cmp::Ord for Amount {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.raw.cmp(&other.raw)
     }
 }
 

--- a/rust/core/src/blocks/block_details.rs
+++ b/rust/core/src/blocks/block_details.rs
@@ -52,7 +52,7 @@ impl BlockDetails {
         let epoch_value = value & epoch_mask;
         let epoch = match FromPrimitive::from_u8(epoch_value) {
             Some(e) => e,
-            None => return Err(anyhow!("unknown epoch value: {}", epoch_value)),
+            None => bail!("unknown epoch value: {}", epoch_value),
         };
 
         Ok(BlockDetails {

--- a/rust/core/src/blocks/builders/legacy_open_block_builder.rs
+++ b/rust/core/src/blocks/builders/legacy_open_block_builder.rs
@@ -65,7 +65,7 @@ impl LegacyOpenBlockBuilder {
     pub fn build(self) -> BlockEnum {
         let source = self.source.unwrap_or(BlockHash::from(1));
         let key_pair = self.keypair.unwrap_or_default();
-        let account = self.account.unwrap_or_else(|| key_pair.public_key().into());
+        let account = self.account.unwrap_or_else(|| key_pair.public_key());
         let representative = self.representative.unwrap_or(Account::from(2));
         let work = self
             .work

--- a/rust/core/src/blocks/builders/test_account_chain.rs
+++ b/rust/core/src/blocks/builders/test_account_chain.rs
@@ -347,7 +347,7 @@ impl TestAccountChain {
             source_epoch,
         });
 
-        if self.blocks.len() > 0 {
+        if !self.blocks.is_empty() {
             let previous = self.blocks.last_mut().unwrap();
             let mut sideband = previous.sideband().unwrap().clone();
             sideband.successor = block.hash();

--- a/rust/core/src/blocks/change_block.rs
+++ b/rust/core/src/blocks/change_block.rs
@@ -111,13 +111,13 @@ impl ChangeBlock {
 }
 
 pub fn valid_change_block_predecessor(predecessor: BlockType) -> bool {
-    match predecessor {
+    matches!(
+        predecessor,
         BlockType::LegacySend
-        | BlockType::LegacyReceive
-        | BlockType::LegacyOpen
-        | BlockType::LegacyChange => true,
-        _ => false,
-    }
+            | BlockType::LegacyReceive
+            | BlockType::LegacyOpen
+            | BlockType::LegacyChange
+    )
 }
 
 impl PartialEq for ChangeBlock {

--- a/rust/core/src/blocks/mod.rs
+++ b/rust/core/src/blocks/mod.rs
@@ -229,10 +229,7 @@ impl BlockEnum {
     }
 
     pub fn is_legacy(&self) -> bool {
-        match self {
-            BlockEnum::State(_) => false,
-            _ => true,
-        }
+        !matches!(self, BlockEnum::State(_))
     }
 
     pub fn balance_opt(&self) -> Option<Amount> {

--- a/rust/core/src/blocks/receive_block.rs
+++ b/rust/core/src/blocks/receive_block.rs
@@ -102,13 +102,13 @@ impl ReceiveBlock {
 }
 
 pub fn valid_receive_block_predecessor(predecessor: BlockType) -> bool {
-    match predecessor {
+    matches!(
+        predecessor,
         BlockType::LegacySend
-        | BlockType::LegacyReceive
-        | BlockType::LegacyOpen
-        | BlockType::LegacyChange => true,
-        _ => false,
-    }
+            | BlockType::LegacyReceive
+            | BlockType::LegacyOpen
+            | BlockType::LegacyChange
+    )
 }
 
 impl PartialEq for ReceiveBlock {

--- a/rust/core/src/blocks/send_block.rs
+++ b/rust/core/src/blocks/send_block.rs
@@ -59,7 +59,7 @@ impl From<&SendHashables> for BlockHash {
         BlockHashBuilder::new()
             .update(hashables.previous.as_bytes())
             .update(hashables.destination.as_bytes())
-            .update(&hashables.balance.to_be_bytes())
+            .update(hashables.balance.to_be_bytes())
             .build()
     }
 }

--- a/rust/core/src/blocks/state_block.rs
+++ b/rust/core/src/blocks/state_block.rs
@@ -35,11 +35,11 @@ impl From<&StateHashables> for BlockHash {
         let mut preamble = [0u8; 32];
         preamble[31] = BlockType::State as u8;
         BlockHashBuilder::new()
-            .update(&preamble)
+            .update(preamble)
             .update(hashables.account.as_bytes())
             .update(hashables.previous.as_bytes())
             .update(hashables.representative.as_bytes())
-            .update(&hashables.balance.to_be_bytes())
+            .update(hashables.balance.to_be_bytes())
             .update(hashables.link.as_bytes())
             .build()
     }

--- a/rust/core/src/difficulty.rs
+++ b/rust/core/src/difficulty.rs
@@ -63,7 +63,7 @@ impl Difficulty for DifficultyV1 {
     }
 
     fn clone(&self) -> Box<dyn Difficulty> {
-        Box::new(DifficultyV1::default())
+        Box::<DifficultyV1>::default()
     }
 }
 

--- a/rust/core/src/epoch.rs
+++ b/rust/core/src/epoch.rs
@@ -88,8 +88,7 @@ impl Epochs {
         validate_message(
             &self
                 .epoch_signer(&block.link())
-                .ok_or_else(|| anyhow!("not an epoch link!"))?
-                .into(),
+                .ok_or_else(|| anyhow!("not an epoch link!"))?,
             block.hash().as_bytes(),
             block.block_signature(),
         )

--- a/rust/core/src/key_pair.rs
+++ b/rust/core/src/key_pair.rs
@@ -96,9 +96,9 @@ pub fn validate_message_batch(
 
 pub fn validate_block_signature(block: &BlockEnum) -> anyhow::Result<()> {
     validate_message(
-        &block.account().into(),
+        &block.account(),
         block.hash().as_bytes(),
-        &block.block_signature(),
+        block.block_signature(),
     )
 }
 

--- a/rust/core/src/u256_struct.rs
+++ b/rust/core/src/u256_struct.rs
@@ -72,19 +72,19 @@ macro_rules! u256_struct {
             }
         }
 
-        impl crate::utils::Serialize for $name {
+        impl $crate::utils::Serialize for $name {
             fn serialized_size() -> usize {
                 32
             }
 
-            fn serialize(&self, stream: &mut dyn crate::utils::Stream) -> anyhow::Result<()> {
+            fn serialize(&self, stream: &mut dyn $crate::utils::Stream) -> anyhow::Result<()> {
                 stream.write_bytes(&self.0)
             }
         }
 
-        impl crate::utils::Deserialize for $name {
+        impl $crate::utils::Deserialize for $name {
             type Target = Self;
-            fn deserialize(stream: &mut dyn crate::utils::Stream) -> anyhow::Result<Self> {
+            fn deserialize(stream: &mut dyn $crate::utils::Stream) -> anyhow::Result<Self> {
                 let mut result = Self::zero();
                 stream.read_bytes(&mut result.0, 32)?;
                 Ok(result)
@@ -109,7 +109,7 @@ macro_rules! u256_struct {
 
         impl std::fmt::Display for $name {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                crate::write_hex_bytes(&self.0, f)
+                $crate::write_hex_bytes(&self.0, f)
             }
         }
     };

--- a/rust/core/src/work/cpu_work_generator.rs
+++ b/rust/core/src/work/cpu_work_generator.rs
@@ -133,7 +133,7 @@ where
         let mut work = 0;
         let mut difficulty = 0;
         while iteration > 0 && difficulty < min_difficulty {
-            (work, difficulty) = self.next(&item);
+            (work, difficulty) = self.next(item);
             iteration -= 1;
         }
 

--- a/rust/core/src/work/opencl_work_generator.rs
+++ b/rust/core/src/work/opencl_work_generator.rs
@@ -26,7 +26,7 @@ impl OpenClWorkGenerator {
         min_difficulty: u64,
         work_ticket: &WorkTicket,
     ) -> Option<(u64, u64)> {
-        let work = (self.opencl)(version, *item, min_difficulty, &work_ticket);
+        let work = (self.opencl)(version, *item, min_difficulty, work_ticket);
         work.map(|work| (work, DifficultyV1::default().get_difficulty(item, work)))
     }
 }
@@ -39,13 +39,13 @@ impl WorkGenerator for OpenClWorkGenerator {
         min_difficulty: u64,
         work_ticket: &WorkTicket,
     ) -> Option<(u64, u64)> {
-        let result = self.create_opencl_work(version, &item, min_difficulty, &work_ticket);
+        let result = self.create_opencl_work(version, item, min_difficulty, work_ticket);
 
         if result.is_some() {
             result
         } else {
             self.cpu_gen
-                .create(version, &item, min_difficulty, &work_ticket)
+                .create(version, item, min_difficulty, work_ticket)
         }
     }
 }

--- a/rust/core/src/work/work_thresholds.rs
+++ b/rust/core/src/work/work_thresholds.rs
@@ -30,11 +30,11 @@ pub struct WorkThresholds {
 impl Clone for WorkThresholds {
     fn clone(&self) -> Self {
         Self {
-            epoch_1: self.epoch_1.clone(),
-            epoch_2: self.epoch_2.clone(),
-            epoch_2_receive: self.epoch_2_receive.clone(),
-            base: self.base.clone(),
-            entry: self.entry.clone(),
+            epoch_1: self.epoch_1,
+            epoch_2: self.epoch_2,
+            epoch_2_receive: self.epoch_2_receive,
+            base: self.base,
+            entry: self.entry,
             difficulty: self.difficulty.clone(),
         }
     }
@@ -117,7 +117,7 @@ impl WorkThresholds {
 impl WorkThresholds {
     pub fn new(epoch_1: u64, epoch_2: u64, epoch_2_receive: u64) -> Self {
         Self::with_difficulty(
-            Box::new(DifficultyV1::default()),
+            Box::<DifficultyV1>::default(),
             epoch_1,
             epoch_2,
             epoch_2_receive,

--- a/rust/ffi/build.rs
+++ b/rust/ffi/build.rs
@@ -13,9 +13,9 @@ fn main() {
         ..Default::default()
     };
 
-    cbindgen::generate_with_config(&crate_dir, config)
+    cbindgen::generate_with_config(crate_dir, config)
         .unwrap()
-        .write_to_file(&output_file);
+        .write_to_file(output_file);
 
     println!("cargo:rerun-if-changed=src");
 }

--- a/rust/ffi/src/core/blocks/mod.rs
+++ b/rust/ffi/src/core/blocks/mod.rs
@@ -165,7 +165,7 @@ pub unsafe extern "C" fn rsn_block_signature_set(handle: *mut BlockHandle, signa
 
 #[no_mangle]
 pub unsafe extern "C" fn rsn_block_previous(handle: &BlockHandle, result: *mut [u8; 32]) {
-    (*result) = *(*handle).block.read().unwrap().previous().as_bytes();
+    (*result) = *(handle).block.read().unwrap().previous().as_bytes();
 }
 
 #[no_mangle]

--- a/rust/ffi/src/core/unchecked_info.rs
+++ b/rust/ffi/src/core/unchecked_info.rs
@@ -44,7 +44,7 @@ pub unsafe extern "C" fn rsn_unchecked_info_clone(
 }
 
 #[no_mangle]
-pub extern "C" fn rsn_unchecked_info_destroy(handle: *mut UncheckedInfoHandle) {
+pub unsafe extern "C" fn rsn_unchecked_info_destroy(handle: *mut UncheckedInfoHandle) {
     drop(unsafe { Box::from_raw(handle) });
 }
 

--- a/rust/ffi/src/gap_cache.rs
+++ b/rust/ffi/src/gap_cache.rs
@@ -93,7 +93,7 @@ pub unsafe extern "C" fn rsn_gap_cache_bootstrap_check(
 
     (*handle)
         .0
-        .bootstrap_check(&voters.into_iter().collect(), &BlockHash::from_ptr(hash))
+        .bootstrap_check(&voters, &BlockHash::from_ptr(hash))
 }
 
 #[no_mangle]

--- a/rust/ffi/src/ledger/datastore/lmdb/block_store.rs
+++ b/rust/ffi/src/ledger/datastore/lmdb/block_store.rs
@@ -134,7 +134,7 @@ pub unsafe extern "C" fn rsn_lmdb_block_store_count(
     handle: *mut LmdbBlockStoreHandle,
     txn: *mut TransactionHandle,
 ) -> u64 {
-    (*handle).0.count((*txn).as_txn()) as u64
+    (*handle).0.count((*txn).as_txn())
 }
 
 #[no_mangle]

--- a/rust/ffi/src/ledger/datastore/lmdb/confirmation_height_store.rs
+++ b/rust/ffi/src/ledger/datastore/lmdb/confirmation_height_store.rs
@@ -89,7 +89,7 @@ pub unsafe extern "C" fn rsn_lmdb_confirmation_height_store_count(
     handle: *mut LmdbConfirmationHeightStoreHandle,
     txn: *mut TransactionHandle,
 ) -> u64 {
-    (*handle).0.count((*txn).as_txn()) as u64
+    (*handle).0.count((*txn).as_txn())
 }
 
 #[no_mangle]

--- a/rust/ffi/src/ledger/datastore/lmdb/mod.rs
+++ b/rust/ffi/src/ledger/datastore/lmdb/mod.rs
@@ -38,7 +38,7 @@ impl TransactionHandle {
     pub fn as_read_txn(&mut self) -> &LmdbReadTransaction {
         match &mut self.0 {
             TransactionType::Read(tx) => tx,
-            TransactionType::ReadRef(tx) => *tx,
+            TransactionType::ReadRef(tx) => tx,
             _ => panic!("invalid tx type"),
         }
     }

--- a/rust/ffi/src/ledger/datastore/lmdb/wallet_store.rs
+++ b/rust/ffi/src/ledger/datastore/lmdb/wallet_store.rs
@@ -322,7 +322,7 @@ pub unsafe extern "C" fn rsn_lmdb_wallet_store_accounts(
     result: *mut U256ArrayDto,
 ) {
     let accounts = (*handle).0.accounts((*txn).as_txn());
-    let data = Box::new(accounts.iter().map(|a| *a.as_bytes()).collect());
+    let data = accounts.iter().map(|a| *a.as_bytes()).collect();
     (*result).initialize(data);
 }
 

--- a/rust/ffi/src/ledger/datastore/lmdb/wallets.rs
+++ b/rust/ffi/src/ledger/datastore/lmdb/wallets.rs
@@ -38,7 +38,7 @@ pub unsafe extern "C" fn rsn_lmdb_wallets_get_wallet_ids(
     result: *mut U256ArrayDto,
 ) {
     let wallet_ids = (*handle).0.get_wallet_ids((*txn).as_txn());
-    let data = Box::new(wallet_ids.iter().map(|i| *i.as_bytes()).collect());
+    let data = wallet_ids.iter().map(|i| *i.as_bytes()).collect();
     (*result).initialize(data)
 }
 

--- a/rust/ffi/src/lib.rs
+++ b/rust/ffi/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::missing_safety_doc)]
+
 #[macro_use]
 extern crate anyhow;
 

--- a/rust/ffi/src/lib.rs
+++ b/rust/ffi/src/lib.rs
@@ -154,7 +154,7 @@ pub unsafe extern "C" fn rsn_callback_is_sanitizer_build(
     IS_SANITIZER_BUILD = f;
 }
 
-pub struct U256ArrayHandle(Box<Vec<[u8; 32]>>);
+pub struct U256ArrayHandle(Vec<[u8; 32]>);
 
 #[repr(C)]
 pub struct U256ArrayDto {
@@ -164,7 +164,7 @@ pub struct U256ArrayDto {
 }
 
 impl U256ArrayDto {
-    pub fn initialize(&mut self, values: Box<Vec<[u8; 32]>>) {
+    pub fn initialize(&mut self, values: Vec<[u8; 32]>) {
         self.items = values.as_ptr();
         self.count = values.len();
         self.handle = Box::into_raw(Box::new(U256ArrayHandle(values)))

--- a/rust/ffi/src/representatives/online_reps.rs
+++ b/rust/ffi/src/representatives/online_reps.rs
@@ -114,7 +114,7 @@ pub unsafe extern "C" fn rsn_online_reps_list(
     result: *mut U256ArrayDto,
 ) {
     let accounts = (*handle).online_reps.lock().unwrap().list();
-    let data = Box::new(accounts.iter().map(|a| *a.as_bytes()).collect());
+    let data = accounts.iter().map(|a| *a.as_bytes()).collect();
     (*result).initialize(data);
 }
 

--- a/rust/ledger/src/block_insertion/validation/epoch_block_rules.rs
+++ b/rust/ledger/src/block_insertion/validation/epoch_block_rules.rs
@@ -40,10 +40,8 @@ impl<'a> BlockValidator<'a> {
     }
 
     fn ensure_epoch_open_has_pending_entry(&self) -> Result<(), ProcessResult> {
-        if self.block.is_open() && self.is_epoch_block() {
-            if !self.any_pending_exists {
-                return Err(ProcessResult::GapEpochOpenPending);
-            };
+        if self.block.is_open() && self.is_epoch_block() && !self.any_pending_exists {
+            return Err(ProcessResult::GapEpochOpenPending);
         }
         Ok(())
     }

--- a/rust/ledger/src/block_insertion/validation/receive_block_rules.rs
+++ b/rust/ledger/src/block_insertion/validation/receive_block_rules.rs
@@ -35,10 +35,10 @@ impl<'a> BlockValidator<'a> {
     }
 
     fn ensure_legacy_source_is_epoch_0(&self) -> Result<(), ProcessResult> {
-        let is_legacy_receive = match self.block {
-            BlockEnum::LegacyReceive(_) | BlockEnum::LegacyOpen(_) => true,
-            _ => false,
-        };
+        let is_legacy_receive = matches!(
+            self.block,
+            BlockEnum::LegacyReceive(_) | BlockEnum::LegacyOpen(_)
+        );
 
         if is_legacy_receive
             && self

--- a/rust/ledger/src/block_rollback/planner_factory.rs
+++ b/rust/ledger/src/block_rollback/planner_factory.rs
@@ -28,7 +28,7 @@ impl<'a, T: Environment + 'static> RollbackPlannerFactory<'a, T> {
         let account = self.get_account(self.head_block)?;
         let planner = RollbackPlanner {
             epochs: &self.ledger.constants.epochs,
-            head_block: &self.head_block,
+            head_block: self.head_block,
             account,
             current_account_info: self.load_account(&account),
             previous_representative: self.get_previous_representative()?,

--- a/rust/ledger/src/block_rollback/rollback_performer.rs
+++ b/rust/ledger/src/block_rollback/rollback_performer.rs
@@ -46,15 +46,16 @@ impl<'a, T: Environment> BlockRollbackPerformer<'a, T> {
     }
 
     fn execute(&mut self, step: RollbackStep, head_block: BlockEnum) -> Result<(), anyhow::Error> {
-        Ok(match step {
+        match step {
             RollbackStep::RollBackBlock(instructions) => {
                 RollbackInstructionsExecutor::new(self.ledger, self.txn, &instructions).execute();
                 self.rolled_back.push(head_block);
+                Ok(())
             }
             RollbackStep::RequestDependencyRollback(dependency_hash) => {
-                self.roll_back_block_and_successors(&dependency_hash)?
+                self.roll_back_block_and_successors(&dependency_hash)
             }
-        })
+        }
     }
 
     fn block_exists(&self, block_hash: &BlockHash) -> bool {

--- a/rust/ledger/src/dependent_blocks_finder.rs
+++ b/rust/ledger/src/dependent_blocks_finder.rs
@@ -48,6 +48,6 @@ impl<'a, T: Environment + 'static> DependentBlocksFinder<'a, T> {
     }
 
     fn is_genesis_open(&self, open: &OpenBlock) -> bool {
-        open.account() == self.ledger.constants.genesis_account.into()
+        open.account() == self.ledger.constants.genesis_account
     }
 }

--- a/rust/ledger/src/ledger_constants.rs
+++ b/rust/ledger/src/ledger_constants.rs
@@ -219,7 +219,7 @@ impl LedgerConstants {
 
         let mut epochs = Epochs::new();
 
-        let epoch_1_signer = genesis.account().into();
+        let epoch_1_signer = genesis.account();
         let epoch_link_v1 = epoch_v1_link();
 
         let nano_live_epoch_v2_signer = Account::decode_account(
@@ -228,9 +228,9 @@ impl LedgerConstants {
         .unwrap();
         let epoch_2_signer = match network {
             Networks::NanoDevNetwork => DEV_GENESIS_KEY.public_key(),
-            Networks::NanoBetaNetwork => nano_beta_account.into(),
-            Networks::NanoLiveNetwork => nano_live_epoch_v2_signer.into(),
-            Networks::NanoTestNetwork => nano_test_account.into(),
+            Networks::NanoBetaNetwork => nano_beta_account,
+            Networks::NanoLiveNetwork => nano_live_epoch_v2_signer,
+            Networks::NanoTestNetwork => nano_test_account,
             _ => panic!("invalid network"),
         };
         let epoch_link_v2 = epoch_v2_link();

--- a/rust/ledger/src/rep_weights.rs
+++ b/rust/ledger/src/rep_weights.rs
@@ -55,8 +55,7 @@ impl RepWeights {
 
     pub fn representation_get(&self, account: &Account) -> Amount {
         let guard = self.rep_amounts.lock().unwrap();
-        let result = self.get(&guard, account);
-        result
+        self.get(&guard, account)
     }
 
     pub fn representation_add_dual(

--- a/rust/node/src/block_processing/backlog_population.rs
+++ b/rust/node/src/block_processing/backlog_population.rs
@@ -155,7 +155,7 @@ impl BacklogPopulationThread {
 
             lock = self
                 .condition
-                .wait_while(lock, |l| !l.stopped && !self.predicate(&l))
+                .wait_while(lock, |l| !l.stopped && !self.predicate(l))
                 .unwrap();
         }
     }

--- a/rust/node/src/bootstrap/bootstrap_attempt.rs
+++ b/rust/node/src/bootstrap/bootstrap_attempt.rs
@@ -141,10 +141,8 @@ impl BootstrapAttempt {
             && self.ledger.block_or_pruned_exists(&hash)
         {
             stop_pull = true;
-        } else {
-            if let Some(p) = self.block_processor.upgrade() {
-                p.add(block);
-            }
+        } else if let Some(p) = self.block_processor.upgrade() {
+            p.add(block);
         }
 
         stop_pull

--- a/rust/node/src/cementation/block_cementer.rs
+++ b/rust/node/src/cementation/block_cementer.rs
@@ -57,7 +57,7 @@ impl BlockCementer {
     }
 
     pub fn block_cache(&self) -> &Arc<BlockCache> {
-        &self.logic.block_cache()
+        self.logic.block_cache()
     }
 
     pub fn process(&mut self, original_block: &BlockEnum, callbacks: &mut CementCallbackRefs) {

--- a/rust/node/src/cementation/block_cementer_logic.rs
+++ b/rust/node/src/cementation/block_cementer_logic.rs
@@ -73,7 +73,6 @@ impl BlockCementerLogic {
         let write_batcher = WriteBatcher::new(WriteBatcherOptions {
             min_batch_size: options.min_batch_size,
             max_pending_writes: options.max_pending_writes,
-            ..Default::default()
         });
 
         Self {
@@ -123,7 +122,7 @@ impl BlockCementerLogic {
     }
 
     pub fn block_cache(&self) -> &Arc<BlockCache> {
-        &self.cementation_walker.block_cache()
+        self.cementation_walker.block_cache()
     }
 
     pub(crate) fn batch_write_size(&self) -> &Arc<BatchWriteSizeManager> {

--- a/rust/node/src/cementation/cementation_thread.rs
+++ b/rust/node/src/cementation/cementation_thread.rs
@@ -53,7 +53,7 @@ impl CementationThread {
 
         let block_cementer = BlockCementer::new(
             ledger,
-            write_database_queue.clone(),
+            write_database_queue,
             logger,
             enable_timing_logging,
             batch_separate_pending_min_time,

--- a/rust/node/src/cementation/cementation_walker.rs
+++ b/rust/node/src/cementation/cementation_walker.rs
@@ -75,7 +75,7 @@ impl ChainIteration {
         self.current_height = block.height() + 1;
     }
 
-    fn into_write_details(&self) -> BlockChainSection {
+    fn to_write_details(&self) -> BlockChainSection {
         BlockChainSection {
             account: self.account,
             bottom_height: self.bottom_height,
@@ -213,7 +213,7 @@ impl CementationWalker {
     }
 
     fn section_to_cement(&self, chain: &ChainIteration) -> Option<BlockChainSection> {
-        let mut write_details = chain.into_write_details();
+        let mut write_details = chain.to_write_details();
         if let Some(info) = self.confirmation_heights.get(&write_details.account) {
             if info.confirmed_height >= write_details.bottom_height {
                 // our bottom is out of date
@@ -267,10 +267,10 @@ impl CementationWalker {
         block: &BlockEnum,
         data_requester: &mut T,
     ) {
-        if let Some(lowest) = self.get_lowest_uncemented_block(&block, data_requester) {
+        if let Some(lowest) = self.get_lowest_uncemented_block(block, data_requester) {
             // There are blocks that need to be cemented in this chain
             self.chain_stack
-                .push_back(ChainIteration::new(&lowest, &block));
+                .push_back(ChainIteration::new(&lowest, block));
             self.chains_encountered += 1;
             if self.chains_encountered % self.chain_stack.max_len() == 0 {
                 // Make a checkpoint every max_len() chains

--- a/rust/node/src/cementation/write_batcher.rs
+++ b/rust/node/src/cementation/write_batcher.rs
@@ -91,7 +91,7 @@ impl WriteBatcher {
     }
 
     pub fn has_pending_writes(&self) -> bool {
-        self.pending_writes.len() > 0
+        !self.pending_writes.is_empty()
     }
 
     pub fn enqueue(&mut self, write_details: BlockChainSection) {

--- a/rust/node/src/messages/asc_pull_ack.rs
+++ b/rust/node/src/messages/asc_pull_ack.rs
@@ -129,7 +129,7 @@ impl AscPullAck {
     }
 
     pub fn payload(&self) -> &AscPullAckPayload {
-        &&self.payload
+        &self.payload
     }
 
     fn serialize_payload(&self, stream: &mut dyn Stream) -> anyhow::Result<()> {

--- a/rust/node/src/messages/confirm_req.rs
+++ b/rust/node/src/messages/confirm_req.rs
@@ -213,18 +213,16 @@ impl Display for ConfirmReq {
             for (hash, root) in &self.roots_hashes {
                 write!(f, "\n{}:{}", hash, root)?;
             }
-        } else {
-            if let Some(block) = &self.block {
-                write!(
-                    f,
-                    "\n{}",
-                    block
-                        .read()
-                        .unwrap()
-                        .to_json()
-                        .map_err(|_| std::fmt::Error)?
-                )?;
-            }
+        } else if let Some(block) = &self.block {
+            write!(
+                f,
+                "\n{}",
+                block
+                    .read()
+                    .unwrap()
+                    .to_json()
+                    .map_err(|_| std::fmt::Error)?
+            )?;
         }
         Ok(())
     }

--- a/rust/node/src/messages/telemetry_ack.rs
+++ b/rust/node/src/messages/telemetry_ack.rs
@@ -157,7 +157,7 @@ impl TelemetryData {
     }
 
     pub fn sign(&mut self, keys: &KeyPair) -> Result<()> {
-        debug_assert!(keys.public_key() == self.node_id.into());
+        debug_assert!(keys.public_key() == self.node_id);
         let mut stream = MemoryStream::new();
         self.serialize_without_signature(&mut stream)?;
         self.signature = sign_message(&keys.private_key(), &keys.public_key(), stream.as_bytes());
@@ -167,7 +167,7 @@ impl TelemetryData {
     pub fn validate_signature(&self) -> bool {
         let mut stream = MemoryStream::new();
         if self.serialize_without_signature(&mut stream).is_ok() {
-            validate_message(&self.node_id.into(), stream.as_bytes(), &self.signature).is_ok()
+            validate_message(&self.node_id, stream.as_bytes(), &self.signature).is_ok()
         } else {
             false
         }
@@ -344,7 +344,7 @@ impl Message for TelemetryAck {
 impl Display for TelemetryAck {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.header.fmt(f)?;
-        write!(f, "\n")?;
+        writeln!(f)?;
         if self.is_empty_payload() {
             write!(f, "empty telemetry payload")?;
         } else {

--- a/rust/node/src/representatives/online_reps.rs
+++ b/rust/node/src/representatives/online_reps.rs
@@ -83,7 +83,7 @@ impl OnlineReps {
 
         let delta =
             U256::from(weight.number()) * U256::from(ONLINE_WEIGHT_QUORUM) / U256::from(100);
-        return Amount::raw(delta.as_u128());
+        Amount::raw(delta.as_u128())
     }
 
     /** List of online representatives, both the currently sampling ones and the ones observed in the previous sampling period */

--- a/rust/node/src/representatives/online_reps_container.rs
+++ b/rust/node/src/representatives/online_reps_container.rs
@@ -22,7 +22,7 @@ impl OnlineRepsContainer {
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &Account> {
-        self.by_account.keys().into_iter()
+        self.by_account.keys()
     }
 
     pub fn clear(&mut self) {

--- a/rust/node/src/representatives/rep_crawler.rs
+++ b/rust/node/src/representatives/rep_crawler.rs
@@ -42,7 +42,7 @@ impl RepCrawler {
 
     pub fn add_rep(&self, rep: Representative) {
         let mut guard = self.probable_reps.lock().unwrap();
-        guard.insert(rep.account().clone(), rep); // todo panic if already added
+        guard.insert(*rep.account(), rep); // todo panic if already added
     }
 
     pub fn remove(&self, hash: &BlockHash) {

--- a/rust/node/src/representatives/representative_collection.rs
+++ b/rust/node/src/representatives/representative_collection.rs
@@ -16,7 +16,7 @@ impl RepresentativeCollection {
     }
 
     pub fn add(&mut self, rep: Representative) {
-        let account = rep.account().clone();
+        let account = *rep.account();
         let channel_id = rep.channel().as_channel().channel_id();
 
         let old = self.by_account.insert(account, rep);

--- a/rust/node/src/signatures/state_block_signature_verification.rs
+++ b/rust/node/src/signatures/state_block_signature_verification.rs
@@ -255,14 +255,13 @@ impl StateBlockSignatureVerificationThread {
             messages.push(block.hash().as_bytes().to_vec());
             let mut account = block.account();
             if !block.link().is_zero() && self.epochs.is_epoch_link(&block.link()) {
-                account = self
+                account = *self
                     .epochs
                     .signer(self.epochs.epoch(&block.link()).unwrap())
-                    .unwrap()
-                    .clone();
+                    .unwrap();
             }
             accounts.push(account);
-            pub_keys.push(account.into());
+            pub_keys.push(account);
             block_signatures.push(block.block_signature().clone())
         }
 

--- a/rust/node/src/stats/ledger_stats.rs
+++ b/rust/node/src/stats/ledger_stats.rs
@@ -35,7 +35,7 @@ impl LedgerObserver for LedgerStats {
     fn block_rolled_back2(&self, block: &BlockEnum, is_epoch: bool) {
         let _ = self.stats.inc(
             StatType::Rollback,
-            block_detail_type(&block, is_epoch),
+            block_detail_type(block, is_epoch),
             Direction::In,
         );
     }

--- a/rust/node/src/transport/channel_inproc.rs
+++ b/rust/node/src/transport/channel_inproc.rs
@@ -129,8 +129,8 @@ impl ChannelInProc {
         let limiter = self.limiter.clone();
         let source_inbound = self.source_inbound.clone();
         let destination_inbound = self.destination_inbound.clone();
-        let source_endpoint = self.source_endpoint.clone();
-        let destination_endpoint = self.destination_endpoint.clone();
+        let source_endpoint = self.source_endpoint;
+        let destination_endpoint = self.destination_endpoint;
         let source_node_id = self.source_node_id;
         let destination_node_id = self.destination_node_id;
         let io_ctx = self.io_ctx.clone();
@@ -173,7 +173,7 @@ impl ChannelInProc {
             }
         });
 
-        self.send_buffer_impl(&buffer_a, callback_wrapper);
+        self.send_buffer_impl(buffer_a, callback_wrapper);
 
         if let Some(cb) = callback_a {
             let buffer_size = buffer_a.len();

--- a/rust/node/src/transport/tcp_server.rs
+++ b/rust/node/src/transport/tcp_server.rs
@@ -557,7 +557,7 @@ impl HandshakeMessageVisitorImpl {
 
         self.stats
             .inc(StatType::Handshake, DetailType::Ok, Direction::In);
-        return true; // OK
+        true // OK
     }
 }
 

--- a/rust/node/src/unchecked_map.rs
+++ b/rust/node/src/unchecked_map.rs
@@ -107,7 +107,7 @@ impl UncheckedMap {
 
     pub fn trigger(&self, dependency: &HashOrAccount) {
         let mut lock = self.mutable.lock().unwrap();
-        lock.buffer.push_back(dependency.clone());
+        lock.buffer.push_back(*dependency);
         drop(lock);
         self.stats
             .inc(StatType::Unchecked, DetailType::Trigger, Direction::In);
@@ -122,6 +122,11 @@ impl UncheckedMap {
     pub fn len(&self) -> usize {
         let lock = self.mutable.lock().unwrap();
         lock.entries_container.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        let lock = self.mutable.lock().unwrap();
+        lock.entries_container.is_empty()
     }
 
     pub fn entries_size() -> usize {

--- a/rust/node/src/utils/thread_pool.rs
+++ b/rust/node/src/utils/thread_pool.rs
@@ -26,8 +26,8 @@ struct ThreadPoolData<T: TimerStrategy> {
 }
 
 impl<T: TimerStrategy> ThreadPoolData<T> {
-    fn push_task(&self, mut callback: Box<dyn FnMut() + Send>) {
-        self.pool.execute(move || callback());
+    fn push_task(&self, callback: Box<dyn FnMut() + Send>) {
+        self.pool.execute(callback);
     }
 }
 

--- a/rust/node/src/voting/inactive_cache_information.rs
+++ b/rust/node/src/voting/inactive_cache_information.rs
@@ -34,7 +34,7 @@ impl InactiveCacheInformation {
 
 impl Display for InactiveCacheInformation {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        write!(f, "hash={}", self.hash.to_string())?;
+        write!(f, "hash={}", self.hash)?;
         write!(f, ", arrival={}", self.arrival)?;
         write!(f, ", {}", self.status)?;
         write!(f, ", {} voters", self.voters.len())?;

--- a/rust/node/src/voting/vote.rs
+++ b/rust/node/src/voting/vote.rs
@@ -45,8 +45,7 @@ impl Vote {
             signature: Signature::new(),
             hashes,
         };
-        result.signature =
-            sign_message(prv, &result.voting_account.into(), result.hash().as_bytes());
+        result.signature = sign_message(prv, &result.voting_account, result.hash().as_bytes());
         result
     }
 
@@ -138,7 +137,7 @@ impl Vote {
 
     pub fn validate(&self) -> Result<()> {
         validate_message(
-            &self.voting_account.into(),
+            &self.voting_account,
             self.hash().as_bytes(),
             &self.signature,
         )

--- a/rust/node/src/voting/vote_spacing.rs
+++ b/rust/node/src/voting/vote_spacing.rs
@@ -43,6 +43,10 @@ impl VoteSpacing {
         self.recent.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.recent.is_empty()
+    }
+
     fn trim(&mut self) {
         self.recent.trim(self.delay);
     }
@@ -135,6 +139,10 @@ impl EntryContainer {
     fn len(&self) -> usize {
         self.entries.len()
     }
+
+    fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
 }
 
 fn change_time_for_entries(
@@ -186,7 +194,7 @@ mod tests {
     fn empty() {
         let spacing = VoteSpacing::new(Duration::from_millis(100));
         assert_eq!(spacing.len(), 0);
-        assert_eq!(spacing.votable(&Root::from(1), &BlockHash::from(2)), true);
+        assert!(spacing.votable(&Root::from(1), &BlockHash::from(2)));
     }
 
     #[test]
@@ -200,8 +208,8 @@ mod tests {
 
         spacing.flag(&root1, &hash1);
         assert_eq!(spacing.len(), 1);
-        assert_eq!(spacing.votable(&root1, &hash1), true);
-        assert_eq!(spacing.votable(&root1, &hash2), false);
+        assert!(spacing.votable(&root1, &hash1));
+        assert!(!spacing.votable(&root1, &hash2));
 
         spacing.flag(&root2, &hash3);
         assert_eq!(spacing.len(), 2);

--- a/rust/store_lmdb/src/account_store.rs
+++ b/rust/store_lmdb/src/account_store.rs
@@ -50,7 +50,7 @@ impl<T: Environment + 'static> LmdbAccountStore<T> {
         info: &AccountInfo,
     ) {
         #[cfg(feature = "output_tracking")]
-        self.put_listener.emit((account.clone(), info.clone()));
+        self.put_listener.emit((*account, info.clone()));
         transaction
             .put(
                 self.database,

--- a/rust/store_lmdb/src/frontier_store.rs
+++ b/rust/store_lmdb/src/frontier_store.rs
@@ -85,7 +85,7 @@ impl<T: Environment + 'static> LmdbFrontierStore<T> {
 
     pub fn put(&self, txn: &mut LmdbWriteTransaction<T>, hash: &BlockHash, account: &Account) {
         #[cfg(feature = "output_tracking")]
-        self.put_listener.emit((hash.clone(), account.clone()));
+        self.put_listener.emit((*hash, *account));
         txn.put(
             self.database,
             hash.as_bytes(),
@@ -109,7 +109,7 @@ impl<T: Environment + 'static> LmdbFrontierStore<T> {
 
     pub fn del(&self, txn: &mut LmdbWriteTransaction<T>, hash: &BlockHash) {
         #[cfg(feature = "output_tracking")]
-        self.delete_listener.emit(hash.clone());
+        self.delete_listener.emit(*hash);
         txn.delete(self.database, hash.as_bytes(), None).unwrap();
     }
 

--- a/rust/store_lmdb/src/iterator.rs
+++ b/rust/store_lmdb/src/iterator.rs
@@ -147,12 +147,10 @@ impl<E: Environment + 'static> LmdbIteratorImpl<E> {
     ) -> Self {
         let operation = if key_val.is_some() {
             MDB_SET_RANGE
+        } else if direction_asc {
+            MDB_FIRST
         } else {
-            if direction_asc {
-                MDB_FIRST
-            } else {
-                MDB_LAST
-            }
+            MDB_LAST
         };
 
         let cursor = txn.open_ro_cursor(dbi).unwrap();

--- a/rust/store_lmdb/src/store.rs
+++ b/rust/store_lmdb/src/store.rs
@@ -106,7 +106,7 @@ impl LmdbStore<EnvironmentStub> {
 }
 
 impl<T: Environment + 'static> LmdbStore<T> {
-    pub fn open<'a>(path: &'a Path) -> LmdbStoreBuilder<'a> {
+    pub fn open(path: &Path) -> LmdbStoreBuilder<'_> {
         LmdbStoreBuilder::new(path)
     }
 
@@ -210,10 +210,8 @@ fn upgrade_if_needed<T: Environment + 'static>(
     }
 
     let env = Arc::new(LmdbEnv::<T>::new(path)?);
-    if !upgrade_info.is_fresh_db {
-        if backup_before_upgrade {
-            create_backup_file(&env, logger.as_ref())?;
-        }
+    if !upgrade_info.is_fresh_db && backup_before_upgrade {
+        create_backup_file(&env, logger.as_ref())?;
     }
 
     logger.always_log("Upgrade in progress...");
@@ -260,7 +258,7 @@ fn copy_table<T: Environment + 'static>(
         let mut cursor = ro_txn.txn().open_ro_cursor(source)?;
         for x in cursor.iter_start() {
             let (k, v) = x?;
-            rw_txn.put(target, &k, &v, WriteFlags::APPEND)?;
+            rw_txn.put(target, k, v, WriteFlags::APPEND)?;
         }
     }
     if ro_txn.txn().count(source) != rw_txn.rw_txn_mut().count(target) {

--- a/rust/store_lmdb/src/store.rs
+++ b/rust/store_lmdb/src/store.rs
@@ -288,7 +288,7 @@ fn do_upgrades<T: Environment + 'static>(
 
     if version < 21 {
         logger.always_log(&format!("The version of the ledger ({}) is lower than the minimum ({}) which is supported for upgrades. Either upgrade to a v23 node first or delete the ledger.", version, STORE_VERSION_MINIMUM));
-        return Err(anyhow!("version too low"));
+        bail!("version too low");
     }
 
     if version > 22 {
@@ -296,7 +296,7 @@ fn do_upgrades<T: Environment + 'static>(
             "The version of the ledger ({}) is too high for this node",
             version
         ));
-        return Err(anyhow!("version too high"));
+        bail!("version too high");
     }
 
     if version == 21 {

--- a/rust/store_lmdb/src/wallets.rs
+++ b/rust/store_lmdb/src/wallets.rs
@@ -67,7 +67,7 @@ impl<T: Environment + 'static> LmdbWallets<T> {
             let mut cursor = rw_txn_source.open_ro_cursor(handle_source)?;
             for x in cursor.iter_start() {
                 let (k, v) = x?;
-                txn_destination.put(handle_destination, &k, &v, WriteFlags::empty())?;
+                txn_destination.put(handle_destination, k, v, WriteFlags::empty())?;
             }
         }
 
@@ -113,7 +113,7 @@ impl<T: Environment + 'static> LmdbWallets<T> {
         let mut i = self.get_store_it(txn, &beginning);
         while let Some((k, _)) = i.current() {
             let text = std::str::from_utf8(k).unwrap();
-            wallet_ids.push(WalletId::decode_hex(&text).unwrap());
+            wallet_ids.push(WalletId::decode_hex(text).unwrap());
             i.next();
         }
         wallet_ids
@@ -124,7 +124,7 @@ impl<T: Environment + 'static> LmdbWallets<T> {
         txn: &dyn crate::Transaction<Database = T::Database, RoCursor = T::RoCursor>,
         id: &str,
     ) -> anyhow::Result<Option<BlockHash>> {
-        match txn.get(self.send_action_ids_handle.unwrap(), &id.as_bytes()) {
+        match txn.get(self.send_action_ids_handle.unwrap(), id.as_bytes()) {
             Ok(bytes) => Ok(Some(
                 BlockHash::from_slice(bytes).ok_or_else(|| anyhow!("invalid block hash"))?,
             )),
@@ -141,7 +141,7 @@ impl<T: Environment + 'static> LmdbWallets<T> {
     ) -> anyhow::Result<()> {
         txn.rw_txn_mut().put(
             self.send_action_ids_handle.unwrap(),
-            &id.as_bytes(),
+            id.as_bytes(),
             hash.as_bytes(),
             WriteFlags::empty(),
         )?;


### PR DESCRIPTION
In order to better understand nano and rs-nano in particular, I cleaned up some code and removed technical debt.
I mostly fixed clippy warnings that are split into two commits:

410975a for things like redundant references and e2f750c for some fixes that are a little bit more complex.

Furthermore there are many `let _ =` statements (e.g. ledger_stats.rs). I left them untouched for now - should those be removed as well?
Let me know, if there are any changes missing or unwanted! Maybe we can set the right clippy rules then.