### PR TITLE
Rsnano/prs/rs insights colors

### DIFF
--- a/rust/tools/insight/src/view_models/message_table_view_model.rs
+++ b/rust/tools/insight/src/view_models/message_table_view_model.rs
@@ -150,11 +150,13 @@ pub(crate) struct MessageTypeOptionViewModel {
 fn message_summary_label(message: &RecordedMessage) -> String {
     match &message.message {
         Message::ConfirmAck(ack) => {
-            let rebroadcast = if ack.is_rebroadcasted() { " rebr" } else { "" };
+            let rebroadcast = if ack.is_rebroadcasted() { " (r)" } else { "" };
+            let final_vote = if ack.vote().is_final() { " (f)" } else { "" };
             format!(
-                "{:?} ({}){}",
+                "{:?} ({}){}{}",
                 message.message.message_type(),
                 ack.vote().hashes.len(),
+                final_vote,
                 rebroadcast
             )
         }

--- a/rust/tools/insight/src/view_models/message_table_view_model.rs
+++ b/rust/tools/insight/src/view_models/message_table_view_model.rs
@@ -4,11 +4,14 @@ use rsnano_core::{Account, BlockHash};
 use rsnano_messages::{Message, MessageType};
 use rsnano_network::ChannelDirection;
 use std::sync::{Arc, RwLock};
+use eframe::egui::Color32;
 
 pub(crate) struct RowViewModel {
     pub channel_id: String,
     pub direction: String,
     pub message: String,
+    pub background_color: Color32,
+    pub text_color: Color32,
     pub is_selected: bool,
 }
 
@@ -43,6 +46,11 @@ impl MessageTableViewModel {
 
     pub(crate) fn get_row(&self, index: usize) -> Option<RowViewModel> {
         let message = self.messages.read().unwrap().get(index)?;
+        
+        let message_text = message_summary_label(&message);
+        let background_color = get_message_background_color(&message.message);
+        let text_color = get_text_color(background_color);
+        
         Some(RowViewModel {
             channel_id: message.channel_id.to_string(),
             direction: if message.direction == ChannelDirection::Inbound {
@@ -50,7 +58,9 @@ impl MessageTableViewModel {
             } else {
                 "out".into()
             },
-            message: message_summary_label(&message),
+            message: message_text,
+            background_color,
+            text_color,
             is_selected: self.selected_index == Some(index),
         })
     }
@@ -146,6 +156,45 @@ pub(crate) struct MessageTypeOptionViewModel {
     pub label: String,
     pub selected: bool,
 }
+
+
+// Define background colors for different message types
+fn get_message_background_color(message: &Message) -> Color32 {
+    match message {
+        // Important messages 
+        Message::Publish(_) => Color32::from_rgb(100, 143, 255),
+        Message::ConfirmAck(_) => Color32::from_rgb(241, 196, 15),
+        Message::ConfirmReq(_) => Color32::from_rgb(231, 76, 60),
+
+        // Less important messages with refined grays
+        Message::AscPullAck(_) => Color32::from_rgb(149, 165, 166),
+        Message::AscPullReq(_) => Color32::from_rgb(127, 140, 141),
+    
+        Message::TelemetryAck(_) => Color32::from_rgb(155, 89, 182),
+        Message::TelemetryReq => Color32::from_rgb(142, 68, 173),
+
+        // Other messages with neutral background
+        Message::Keepalive(_) => Color32::from_rgb(52, 73, 94),
+        Message::BulkPull(_) => Color32::from_rgb(52, 73, 94),
+        Message::BulkPullAccount(_) => Color32::from_rgb(52, 73, 94),
+        Message::BulkPush => Color32::from_rgb(52, 73, 94),
+        Message::FrontierReq(_) => Color32::from_rgb(52, 73, 94),
+        Message::NodeIdHandshake(_) => Color32::from_rgb(52, 73, 94),
+    }
+}
+
+fn get_text_color(background: Color32) -> Color32 {
+    let luminance = (0.299 * background.r() as f32 + 
+                    0.587 * background.g() as f32 + 
+                    0.114 * background.b() as f32) / 255.0;
+    
+    if luminance > 0.5 {
+        Color32::BLACK
+    } else {
+        Color32::WHITE
+    }
+}
+
 
 fn message_summary_label(message: &RecordedMessage) -> String {
     match &message.message {

--- a/rust/tools/insight/src/views/message_tab_view.rs
+++ b/rust/tools/insight/src/views/message_tab_view.rs
@@ -29,7 +29,7 @@ impl<'a> MessageTabView<'a> {
     fn show_message_overview(&mut self, ctx: &egui::Context) {
         SidePanel::left("messages_panel")
             .min_width(250.0)
-            .resizable(false)
+            .resizable(true)
             .show(ctx, |ui| {
                 MessageTableView::new(&mut self.model.message_table).view(ui);
             });

--- a/rust/tools/insight/src/views/message_table_view.rs
+++ b/rust/tools/insight/src/views/message_table_view.rs
@@ -1,5 +1,5 @@
 use crate::view_models::MessageTableViewModel;
-use eframe::egui::{CentralPanel, Color32, Label, Sense, TextEdit, TopBottomPanel, Ui};
+use eframe::egui::{CentralPanel, Color32, Label, Sense, TextEdit, TopBottomPanel, Ui, RichText};
 use egui_extras::{Column, TableBuilder};
 
 pub(crate) struct MessageTableView<'a> {
@@ -104,9 +104,12 @@ impl<'a> MessageTableView<'a> {
                     let Some(row_model) = self.model.get_row(row.index()) else {
                         return;
                     };
-                    if row_model.is_selected {
-                        row.set_selected(true);
-                    }
+                    // Set the background color based on whether the row is selected
+                    let bg_color = if row_model.is_selected {
+                        row_model.background_color.linear_multiply(2.0)
+                    } else {
+                        row_model.background_color
+                    };
                     row.col(|ui| {
                         ui.add(Label::new(row_model.channel_id).selectable(false));
                     });
@@ -114,8 +117,15 @@ impl<'a> MessageTableView<'a> {
                         ui.add(Label::new(row_model.direction).selectable(false));
                     });
                     row.col(|ui| {
-                        ui.add(Label::new(row_model.message).selectable(false));
-                    });
+                        ui.painter().rect_filled(
+                            ui.available_rect_before_wrap(),
+                            0.0,
+                            bg_color
+                        );
+                        ui.add(
+                            Label::new(RichText::new(&row_model.message).color(row_model.text_color)).selectable(false)
+                        );
+                    });    
                     if row.response().clicked() {
                         self.model.select_message(row.index());
                     }


### PR DESCRIPTION
- Added:
  - (f) for final confirm_acks
  -  colored messages.
- Changes:
  - "rebr" to (r) on confirm_acks for shortness
  - allow message panel resizing

<img width="1002" alt="Screenshot 2024-10-23 at 10 16 04" src="https://github.com/user-attachments/assets/dce04df5-4532-450b-b51b-ca19254027f5">
<img width="1018" alt="Screenshot 2024-10-23 at 10 16 10" src="https://github.com/user-attachments/assets/57d78853-5ac1-491f-9a02-7cef162e6891">
