### PR TITLE
Add BlockProcessor & VoteProcessor to the Queues Dashboard

### DIFF
--- a/rust/node/src/consensus/rep_tiers.rs
+++ b/rust/node/src/consensus/rep_tiers.rs
@@ -19,7 +19,7 @@ use strum_macros::EnumIter;
 use tracing::debug;
 
 // Higher number means higher priority
-#[derive(FromPrimitive, Copy, Clone, PartialOrd, Ord, PartialEq, Eq, EnumIter)]
+#[derive(FromPrimitive, Copy, Clone, PartialOrd, Ord, PartialEq, Eq, EnumIter, Hash, Debug)]
 pub enum RepTier {
     None,  // Not a principal representatives
     Tier1, // (0.1-1%) of online stake

--- a/rust/node/src/transport/fair_queue.rs
+++ b/rust/node/src/transport/fair_queue.rs
@@ -142,6 +142,10 @@ where
         }
     }
 
+    pub fn iter_queues(&self) -> impl Iterator<Item = (&S, &Entry<T>)> {
+        self.queues.iter()
+    }
+
     pub fn collect_container_info(&self, name: impl Into<String>) -> ContainerInfoComponent {
         ContainerInfoComponent::Composite(
             name.into(),
@@ -188,7 +192,7 @@ where
     }
 }
 
-struct Entry<T> {
+pub(crate) struct Entry<T> {
     requests: VecDeque<T>,
     priority: usize,
     max_size: usize,

--- a/rust/tools/insight/src/view_models/app_view_model.rs
+++ b/rust/tools/insight/src/view_models/app_view_model.rs
@@ -7,7 +7,7 @@ use crate::{
     message_recorder::MessageRecorder, node_factory::NodeFactory, node_runner::NodeRunner,
     nullable_runtime::NullableRuntime,
 };
-use rsnano_node::{cementation::ConfirmingSetInfo, consensus::ActiveElectionsInfo};
+use rsnano_node::{block_processing::BlockProcessorInfo, cementation::ConfirmingSetInfo, consensus::ActiveElectionsInfo};
 use rsnano_nullable_clock::{SteadyClock, Timestamp};
 use std::{
     sync::{Arc, RwLock},
@@ -25,6 +25,7 @@ pub(crate) struct AppViewModel {
     last_update: Option<Timestamp>,
     pub aec_info: ActiveElectionsInfo,
     pub confirming_set: ConfirmingSetInfo,
+    pub block_processor_info: BlockProcessorInfo,
 }
 
 impl AppViewModel {
@@ -44,6 +45,7 @@ impl AppViewModel {
             last_update: None,
             aec_info: Default::default(),
             confirming_set: Default::default(),
+            block_processor_info: Default::default(),
         }
     }
 
@@ -80,6 +82,7 @@ impl AppViewModel {
             );
             self.aec_info = node.active.info();
             self.confirming_set = node.confirming_set.info();
+            self.block_processor_info = node.block_processor.info();
         }
 
         self.message_table.update_message_counts();

--- a/rust/tools/insight/src/view_models/app_view_model.rs
+++ b/rust/tools/insight/src/view_models/app_view_model.rs
@@ -7,7 +7,8 @@ use crate::{
     message_recorder::MessageRecorder, node_factory::NodeFactory, node_runner::NodeRunner,
     nullable_runtime::NullableRuntime,
 };
-use rsnano_node::{block_processing::BlockProcessorInfo, cementation::ConfirmingSetInfo, consensus::ActiveElectionsInfo};
+use rsnano_node::{block_processing::BlockProcessorInfo, consensus::VoteProcessorInfo,
+    cementation::ConfirmingSetInfo, consensus::ActiveElectionsInfo};
 use rsnano_nullable_clock::{SteadyClock, Timestamp};
 use std::{
     sync::{Arc, RwLock},
@@ -26,6 +27,7 @@ pub(crate) struct AppViewModel {
     pub aec_info: ActiveElectionsInfo,
     pub confirming_set: ConfirmingSetInfo,
     pub block_processor_info: BlockProcessorInfo,
+    pub vote_processor_info: VoteProcessorInfo,
 }
 
 impl AppViewModel {
@@ -46,6 +48,7 @@ impl AppViewModel {
             aec_info: Default::default(),
             confirming_set: Default::default(),
             block_processor_info: Default::default(),
+            vote_processor_info: Default::default(),
         }
     }
 
@@ -83,6 +86,7 @@ impl AppViewModel {
             self.aec_info = node.active.info();
             self.confirming_set = node.confirming_set.info();
             self.block_processor_info = node.block_processor.info();
+            self.vote_processor_info = node.vote_processor_queue.info();
         }
 
         self.message_table.update_message_counts();


### PR DESCRIPTION
I played around and added some of the FairQueues with the help of GPT.
I'll put it up as draft as I'm not confident or works correctly.

<img width="674" alt="Screenshot 2024-10-23 at 21 20 49" src="https://github.com/user-attachments/assets/253bc27d-3d30-4926-a284-720c8e30f388">
