### PR TITLE
align with c++

### DIFF
--- a/rpc_server/src/command_handler/ledger/blocks_info.rs
+++ b/rpc_server/src/command_handler/ledger/blocks_info.rs
@@ -55,7 +55,7 @@ impl RpcCommandHandler {
                 };
 
                 if receivable || receive_hash {
-                    if block.is_send() {
+                    if !block.is_send() {
                         if receivable {
                             block_info.receivable = Some(0.into());
                         }


### PR DESCRIPTION
There was a slight mismatch between c++ and rust implementation of the `blocks_info` rpc.

Here is the corresponding c++ line :
https://github.com/nanocurrency/nano-node/blob/7855c82da7d8d80db92829d377d2d0723d26cbe9/nano/node/json_handler.cpp#L1328