### PR TITLE
Fix unchecked count in block_count RPC

### DIFF
--- a/rpc_server/src/command_handler/ledger/block_count.rs
+++ b/rpc_server/src/command_handler/ledger/block_count.rs
@@ -4,7 +4,7 @@ use rsnano_rpc_messages::BlockCountResponse;
 impl RpcCommandHandler {
     pub(crate) fn block_count(&self) -> BlockCountResponse {
         let count = self.node.ledger.block_count();
-        let unchecked = self.node.unchecked.buffer_count() as u64;
+        let unchecked = self.node.unchecked.len() as u64;
         let cemented = self.node.ledger.cemented_count();
         BlockCountResponse {
             count: count.into(),


### PR DESCRIPTION
Unchecked blocks in block_count RPC is always 0 during bootstrap. This change appear to fix it, using the same method that telemetry RPC uses to get unchecked block count. 