### PR TITLE
Allow json int and json bool in rpc request (closes #179)

### DIFF
--- a/rpc_messages/src/common/primitives.rs
+++ b/rpc_messages/src/common/primitives.rs
@@ -80,13 +80,62 @@ macro_rules! rpc_number {
 
 //serde_json forwards visit_u8, etc to visit_u64, visit_f32 to visit_f64
 //this is because serde_json handles integers as u64, and floating points as f64
-rpc_number!(RpcU8, u8, RpcU8Visitor, derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord), visit_u64, u64);
-rpc_number!(RpcU16, u16, RpcU16Visitor, derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord), visit_u64, u64);
-rpc_number!(RpcU32, u32, RpcU32Visitor, derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord), visit_u64, u64);
-rpc_number!(RpcU64, u64, RpcU64Visitor, derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord), visit_u64, u64);
-rpc_number!(RpcF32, f32, RpcF32Visitor, derive(Copy, Clone, PartialEq, Default, PartialOrd), visit_f64, f64);
-rpc_number!(RpcF64, f64, RpcF64Visitor, derive(Copy, Clone, PartialEq, Default, PartialOrd), visit_f64, f64);
-rpc_number!(RpcUsize, usize, RpcUsizeVisitor, derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord), visit_u64, u64);
+rpc_number!(
+    RpcU8,
+    u8,
+    RpcU8Visitor,
+    derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord),
+    visit_u64,
+    u64
+);
+rpc_number!(
+    RpcU16,
+    u16,
+    RpcU16Visitor,
+    derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord),
+    visit_u64,
+    u64
+);
+rpc_number!(
+    RpcU32,
+    u32,
+    RpcU32Visitor,
+    derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord),
+    visit_u64,
+    u64
+);
+rpc_number!(
+    RpcU64,
+    u64,
+    RpcU64Visitor,
+    derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord),
+    visit_u64,
+    u64
+);
+rpc_number!(
+    RpcF32,
+    f32,
+    RpcF32Visitor,
+    derive(Copy, Clone, PartialEq, Default, PartialOrd),
+    visit_f64,
+    f64
+);
+rpc_number!(
+    RpcF64,
+    f64,
+    RpcF64Visitor,
+    derive(Copy, Clone, PartialEq, Default, PartialOrd),
+    visit_f64,
+    f64
+);
+rpc_number!(
+    RpcUsize,
+    usize,
+    RpcUsizeVisitor,
+    derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord),
+    visit_u64,
+    u64
+);
 
 impl From<RpcU64> for usize {
     fn from(value: RpcU64) -> Self {

--- a/rpc_messages/src/common/primitives.rs
+++ b/rpc_messages/src/common/primitives.rs
@@ -3,8 +3,8 @@ use std::fmt::Debug;
 
 #[macro_export]
 macro_rules! rpc_number {
-    ($name:ident, $type:ty, $visitor:ident) => {
-        #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord)]
+    ($name:ident, $type:ty, $visitor:ident, $derive:meta, $name_visitor:ident, $visitor_type:ty) => {
+        #[$derive]
         pub struct $name($type);
 
         impl $name{
@@ -45,7 +45,7 @@ macro_rules! rpc_number {
             where
                 D: serde::Deserializer<'de>,
             {
-                deserializer.deserialize_str($visitor {})
+                deserializer.deserialize_any($visitor {})
             }
         }
 
@@ -67,143 +67,30 @@ macro_rules! rpc_number {
                     .map_err(|_| serde::de::Error::custom(stringify!("expected " $type)))?;
                 Ok(value.into())
             }
+
+            fn $name_visitor<E>(self, v: $visitor_type) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok($name(v as $type))
+            }
         }
     };
 }
 
-rpc_number!(RpcU8, u8, RpcU8Visitor);
-rpc_number!(RpcU16, u16, RpcU16Visitor);
-rpc_number!(RpcU32, u32, RpcU32Visitor);
-rpc_number!(RpcU64, u64, RpcU64Visitor);
-rpc_number!(RpcUsize, usize, RpcUsizeVisitor);
+//serde_json forwards visit_u8, etc to visit_u64, visit_f32 to visit_f64
+//this is because serde_json handles integers as u64, and floating points as f64
+rpc_number!(RpcU8, u8, RpcU8Visitor, derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord), visit_u64, u64);
+rpc_number!(RpcU16, u16, RpcU16Visitor, derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord), visit_u64, u64);
+rpc_number!(RpcU32, u32, RpcU32Visitor, derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord), visit_u64, u64);
+rpc_number!(RpcU64, u64, RpcU64Visitor, derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord), visit_u64, u64);
+rpc_number!(RpcF32, f32, RpcF32Visitor, derive(Copy, Clone, PartialEq, Default, PartialOrd), visit_f64, f64);
+rpc_number!(RpcF64, f64, RpcF64Visitor, derive(Copy, Clone, PartialEq, Default, PartialOrd), visit_f64, f64);
+rpc_number!(RpcUsize, usize, RpcUsizeVisitor, derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord), visit_u64, u64);
 
 impl From<RpcU64> for usize {
     fn from(value: RpcU64) -> Self {
         value.inner() as usize
-    }
-}
-
-#[derive(Copy, Clone, PartialEq, Default, PartialOrd)]
-pub struct RpcF32(f32);
-
-impl From<f32> for RpcF32 {
-    fn from(value: f32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<RpcF32> for f32 {
-    fn from(value: RpcF32) -> Self {
-        value.0
-    }
-}
-
-impl Debug for RpcF32 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl Serialize for RpcF32 {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&self.0.to_string())
-    }
-}
-
-impl<'de> Deserialize<'de> for RpcF32 {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        deserializer.deserialize_str(F32Visitor {})
-    }
-}
-
-struct F32Visitor {}
-
-impl<'de> Visitor<'de> for F32Visitor {
-    type Value = RpcF32;
-
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("f32")
-    }
-
-    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-    where
-        E: serde::de::Error,
-    {
-        let value = v
-            .parse::<f32>()
-            .map_err(|_| serde::de::Error::custom("expected f32"))?;
-        Ok(value.into())
-    }
-}
-
-#[derive(Copy, Clone, PartialEq, Default, PartialOrd)]
-pub struct RpcF64(f64);
-
-impl RpcF64 {
-    pub fn inner(&self) -> f64 {
-        self.0
-    }
-}
-
-impl From<f64> for RpcF64 {
-    fn from(value: f64) -> Self {
-        Self(value)
-    }
-}
-
-impl From<RpcF64> for f64 {
-    fn from(value: RpcF64) -> Self {
-        value.0
-    }
-}
-
-impl Debug for RpcF64 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl Serialize for RpcF64 {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&self.0.to_string())
-    }
-}
-
-impl<'de> Deserialize<'de> for RpcF64 {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        deserializer.deserialize_str(F64Visitor {})
-    }
-}
-
-struct F64Visitor {}
-
-impl<'de> Visitor<'de> for F64Visitor {
-    type Value = RpcF64;
-
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("f64")
-    }
-
-    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-    where
-        E: serde::de::Error,
-    {
-        let value = v
-            .parse::<f64>()
-            .map_err(|_| serde::de::Error::custom("expected f64"))?;
-        Ok(value.into())
     }
 }
 
@@ -243,7 +130,7 @@ impl<'de> Deserialize<'de> for RpcBoolNumber {
     where
         D: serde::Deserializer<'de>,
     {
-        let result = deserializer.deserialize_str(BoolVisitor {})?;
+        let result = deserializer.deserialize_any(BoolVisitor {})?;
         Ok(RpcBoolNumber(result))
     }
 }
@@ -289,7 +176,7 @@ impl<'de> Deserialize<'de> for RpcBool {
     where
         D: serde::Deserializer<'de>,
     {
-        let result = deserializer.deserialize_str(BoolVisitor {})?;
+        let result = deserializer.deserialize_any(BoolVisitor {})?;
         Ok(RpcBool(result))
     }
 }
@@ -300,7 +187,7 @@ impl<'de> Visitor<'de> for BoolVisitor {
     type Value = bool;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("bool")
+        formatter.write_str("bool, string of bool, or 0/1 as string")
     }
 
     fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
@@ -312,6 +199,14 @@ impl<'de> Visitor<'de> for BoolVisitor {
             "0" | "false" => Ok(false),
             _ => Err(serde::de::Error::custom("bool expected")),
         }
+    }
+
+    //infallible
+    fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(v)
     }
 }
 
@@ -340,6 +235,22 @@ mod tests {
     use super::*;
 
     #[test]
+    fn u8_serialize() {
+        let value = RpcU8::from(123);
+        assert_eq!(format!("{:?}", value), "123");
+        let json = serde_json::to_string(&value).unwrap();
+        assert_eq!(json, "\"123\"");
+    }
+
+    #[test]
+    fn u8_deserialize() {
+        let a: RpcU8 = serde_json::from_str("\"123\"").unwrap();
+        let b: RpcU8 = serde_json::from_str("123").unwrap();
+        assert_eq!(a, 123.into());
+        assert_eq!(b, 123.into());
+    }
+
+    #[test]
     fn u16_serialize() {
         let value = RpcU16::from(123);
         assert_eq!(format!("{:?}", value), "123");
@@ -349,8 +260,26 @@ mod tests {
 
     #[test]
     fn u16_deserialize() {
-        let value: RpcU16 = serde_json::from_str("\"123\"").unwrap();
-        assert_eq!(value, 123.into());
+        let a: RpcU16 = serde_json::from_str("\"123\"").unwrap();
+        let b: RpcU16 = serde_json::from_str("123").unwrap();
+        assert_eq!(a, 123.into());
+        assert_eq!(b, 123.into());
+    }
+
+    #[test]
+    fn u32_serialize() {
+        let value = RpcU32::from(123);
+        assert_eq!(format!("{:?}", value), "123");
+        let json = serde_json::to_string(&value).unwrap();
+        assert_eq!(json, "\"123\"");
+    }
+
+    #[test]
+    fn u32_deserialize() {
+        let a: RpcU32 = serde_json::from_str("\"123\"").unwrap();
+        let b: RpcU32 = serde_json::from_str("123").unwrap();
+        assert_eq!(a, 123.into());
+        assert_eq!(b, 123.into());
     }
 
     #[test]
@@ -363,8 +292,26 @@ mod tests {
 
     #[test]
     fn u64_deserialize() {
-        let value: RpcU64 = serde_json::from_str("\"123\"").unwrap();
-        assert_eq!(value, 123.into());
+        let a: RpcU64 = serde_json::from_str("\"123\"").unwrap();
+        let b: RpcU64 = serde_json::from_str("123").unwrap();
+        assert_eq!(a, 123.into());
+        assert_eq!(b, 123.into());
+    }
+
+    #[test]
+    fn usize_serialize() {
+        let value = RpcUsize::from(123);
+        assert_eq!(format!("{:?}", value), "123");
+        let json = serde_json::to_string(&value).unwrap();
+        assert_eq!(json, "\"123\"");
+    }
+
+    #[test]
+    fn usize_deserialize() {
+        let a: RpcUsize = serde_json::from_str("\"123\"").unwrap();
+        let b: RpcUsize = serde_json::from_str("123").unwrap();
+        assert_eq!(a, 123.into());
+        assert_eq!(b, 123.into());
     }
 
     #[test]
@@ -377,8 +324,26 @@ mod tests {
 
     #[test]
     fn f32_deserialize() {
-        let value: RpcF32 = serde_json::from_str("\"1.23\"").unwrap();
-        assert_eq!(value, 1.23.into());
+        let a: RpcF32 = serde_json::from_str("\"1.23\"").unwrap();
+        let b: RpcF32 = serde_json::from_str("1.23").unwrap();
+        assert_eq!(a, 1.23.into());
+        assert_eq!(b, 1.23.into());
+    }
+
+    #[test]
+    fn f64_serialize() {
+        let value = RpcF32::from(1.23);
+        assert_eq!(format!("{:?}", value), "1.23");
+        let json = serde_json::to_string(&value).unwrap();
+        assert_eq!(json, "\"1.23\"");
+    }
+
+    #[test]
+    fn f64_deserialize() {
+        let a: RpcF64 = serde_json::from_str("\"1.23\"").unwrap();
+        let b: RpcF64 = serde_json::from_str("1.23").unwrap();
+        assert_eq!(a, 1.23.into());
+        assert_eq!(b, 1.23.into());
     }
 
     #[test]
@@ -399,10 +364,14 @@ mod tests {
         let b: RpcBoolNumber = serde_json::from_str("\"0\"").unwrap();
         let c: RpcBoolNumber = serde_json::from_str("\"true\"").unwrap();
         let d: RpcBoolNumber = serde_json::from_str("\"false\"").unwrap();
+        let e: RpcBoolNumber = serde_json::from_str("true").unwrap();
+        let f: RpcBoolNumber = serde_json::from_str("false").unwrap();
         assert_eq!(a, true.into());
         assert_eq!(b, false.into());
         assert_eq!(c, true.into());
         assert_eq!(d, false.into());
+        assert_eq!(e, true.into());
+        assert_eq!(f, false.into());
     }
 
     #[test]
@@ -419,13 +388,17 @@ mod tests {
 
     #[test]
     fn bool_deserialize() {
-        let a: RpcBoolNumber = serde_json::from_str("\"1\"").unwrap();
-        let b: RpcBoolNumber = serde_json::from_str("\"0\"").unwrap();
-        let c: RpcBoolNumber = serde_json::from_str("\"true\"").unwrap();
-        let d: RpcBoolNumber = serde_json::from_str("\"false\"").unwrap();
+        let a: RpcBool = serde_json::from_str("\"1\"").unwrap();
+        let b: RpcBool = serde_json::from_str("\"0\"").unwrap();
+        let c: RpcBool = serde_json::from_str("\"true\"").unwrap();
+        let d: RpcBool = serde_json::from_str("\"false\"").unwrap();
+        let e: RpcBool = serde_json::from_str("true").unwrap();
+        let f: RpcBool = serde_json::from_str("false").unwrap();
         assert_eq!(a, true.into());
         assert_eq!(b, false.into());
         assert_eq!(c, true.into());
         assert_eq!(d, false.into());
+        assert_eq!(e, true.into());
+        assert_eq!(f, false.into());
     }
 }


### PR DESCRIPTION
Closes #179, allowing deserialisation of JSON bools and JSON ints, instead of requiring only bools and ints inside strings.

Changes how `rpc_number` to make it more powerful and apply to f32 and f64 too. That macro doesn't seem to be used anywhere else, so I assume this is fine.

Adds previously missing tests (eg for serial/deserial for f64, usize, etc), and adds tests that check that the new json int and json bool deserial work.

Since serde_json treats integers as u64 and floating points as f64, there is a possibility that conversion to u32, u16, u8, f32 do not give the expected result, but `as` doesn't panic afaik so this is the problem of the client for sending us bad input, and shouldn't affect us?
