### PR TITLE
Prs/rsnano wallet context

### DIFF
--- a/main/src/cli/commands/wallets/add_private_key.rs
+++ b/main/src/cli/commands/wallets/add_private_key.rs
@@ -1,7 +1,8 @@
-use crate::cli::{GlobalArgs, build_node};
+use crate::cli::GlobalArgs;
+use crate::cli::commands::wallets::WalletContext;
 use anyhow::anyhow;
 use clap::Parser;
-use rsnano_types::{RawKey, WalletId};
+use rsnano_types::RawKey;
 
 #[derive(Parser, PartialEq, Debug)]
 pub(crate) struct AddPrivateKeyArgs {
@@ -18,13 +19,10 @@ pub(crate) struct AddPrivateKeyArgs {
 
 impl AddPrivateKeyArgs {
     pub(crate) fn add_key(&self, global_args: GlobalArgs) -> anyhow::Result<()> {
-        let node = build_node(&global_args)?;
-        let wallet_id =
-            WalletId::decode_hex(&self.wallet).ok_or_else(|| anyhow!("Invalid wallet id"))?;
+        let context = WalletContext::from_args(&global_args, &self.wallet, &self.password)?;
+        let (node, wallet_id) = context.into_parts();
         let private_key =
             RawKey::decode_hex(&self.private_key).ok_or_else(|| anyhow!("Invalid private key"))?;
-        let password = self.password.clone().unwrap_or_default();
-        node.wallets.ensure_wallet_is_unlocked(wallet_id, &password);
 
         node.wallets
             .insert_adhoc2(&wallet_id, &private_key, false)

--- a/main/src/cli/commands/wallets/change_wallet_seed.rs
+++ b/main/src/cli/commands/wallets/change_wallet_seed.rs
@@ -1,7 +1,8 @@
-use crate::cli::{GlobalArgs, build_node};
+use crate::cli::GlobalArgs;
+use crate::cli::commands::wallets::WalletContext;
 use anyhow::anyhow;
 use clap::Parser;
-use rsnano_types::{RawKey, WalletId};
+use rsnano_types::RawKey;
 
 #[derive(Parser, PartialEq, Debug)]
 pub(crate) struct ChangeWalletSeedArgs {
@@ -18,13 +19,9 @@ pub(crate) struct ChangeWalletSeedArgs {
 
 impl ChangeWalletSeedArgs {
     pub(crate) fn change_wallet_seed(&self, global_args: GlobalArgs) -> anyhow::Result<()> {
-        let node = build_node(&global_args)?;
-        let wallet_id =
-            WalletId::decode_hex(&self.wallet).ok_or_else(|| anyhow!("Invalid wallet id"))?;
+        let context = WalletContext::from_args(&global_args, &self.wallet, &self.password)?;
+        let (node, wallet_id) = context.into_parts();
         let seed = RawKey::decode_hex(&self.seed).ok_or_else(|| anyhow!("Invalid seed"))?;
-        let password = self.password.clone().unwrap_or_default();
-
-        node.wallets.ensure_wallet_is_unlocked(wallet_id, &password);
 
         node.wallets
             .change_seed(wallet_id, &seed, 0)

--- a/main/src/cli/commands/wallets/create_account.rs
+++ b/main/src/cli/commands/wallets/create_account.rs
@@ -1,7 +1,8 @@
-use crate::cli::{GlobalArgs, build_node};
+use crate::cli::GlobalArgs;
+use crate::cli::commands::wallets::WalletContext;
 use anyhow::anyhow;
 use clap::Parser;
-use rsnano_types::{Account, WalletId};
+use rsnano_types::Account;
 
 #[derive(Parser, PartialEq, Debug)]
 pub(crate) struct CreateAccountArgs {
@@ -15,12 +16,8 @@ pub(crate) struct CreateAccountArgs {
 
 impl CreateAccountArgs {
     pub(crate) fn create_account(&self, global_args: GlobalArgs) -> anyhow::Result<()> {
-        let node = build_node(&global_args)?;
-        let wallet =
-            WalletId::decode_hex(&self.wallet).ok_or_else(|| anyhow!("Invalid wallet id"))?;
-        let password = self.password.clone().unwrap_or_default();
-
-        node.wallets.ensure_wallet_is_unlocked(wallet, &password);
+        let context = WalletContext::from_args(&global_args, &self.wallet, &self.password)?;
+        let (node, wallet) = context.into_parts();
 
         let public_key = node
             .wallets

--- a/main/src/cli/commands/wallets/decrypt_wallet.rs
+++ b/main/src/cli/commands/wallets/decrypt_wallet.rs
@@ -1,7 +1,7 @@
-use crate::cli::{GlobalArgs, build_node};
+use crate::cli::GlobalArgs;
+use crate::cli::commands::wallets::WalletContext;
 use anyhow::anyhow;
 use clap::Parser;
-use rsnano_types::WalletId;
 
 #[derive(Parser, PartialEq, Debug)]
 pub(crate) struct DecryptWalletArgs {
@@ -15,12 +15,8 @@ pub(crate) struct DecryptWalletArgs {
 
 impl DecryptWalletArgs {
     pub(crate) fn decrypt_wallet(&self, global_args: GlobalArgs) -> anyhow::Result<()> {
-        let node = build_node(&global_args)?;
-        let wallet_id =
-            WalletId::decode_hex(&self.wallet).ok_or_else(|| anyhow!("Invalid wallet id"))?;
-        let password = self.password.clone().unwrap_or_default();
-
-        node.wallets.ensure_wallet_is_unlocked(wallet_id, &password);
+        let context = WalletContext::from_args(&global_args, &self.wallet, &self.password)?;
+        let (node, wallet_id) = context.into_parts();
 
         let seed = node
             .wallets

--- a/main/src/cli/commands/wallets/destroy_wallet.rs
+++ b/main/src/cli/commands/wallets/destroy_wallet.rs
@@ -1,7 +1,6 @@
-use crate::cli::{GlobalArgs, build_node};
-use anyhow::anyhow;
+use crate::cli::GlobalArgs;
+use crate::cli::commands::wallets::WalletContext;
 use clap::Parser;
-use rsnano_types::WalletId;
 
 #[derive(Parser, PartialEq, Debug)]
 pub(crate) struct DestroyWalletArgs {
@@ -15,11 +14,8 @@ pub(crate) struct DestroyWalletArgs {
 
 impl DestroyWalletArgs {
     pub(crate) fn destroy_wallet(&self, global_args: GlobalArgs) -> anyhow::Result<()> {
-        let node = build_node(&global_args)?;
-        let wallet_id =
-            WalletId::decode_hex(&self.wallet).ok_or_else(|| anyhow!("Invalid wallet id"))?;
-        let password = self.password.clone().unwrap_or_default();
-        node.wallets.ensure_wallet_is_unlocked(wallet_id, &password);
+        let context = WalletContext::from_args(&global_args, &self.wallet, &self.password)?;
+        let (node, wallet_id) = context.into_parts();
         node.wallets.destroy(&wallet_id);
         Ok(())
     }

--- a/main/src/cli/commands/wallets/get_wallet_representative.rs
+++ b/main/src/cli/commands/wallets/get_wallet_representative.rs
@@ -1,7 +1,8 @@
-use crate::cli::{GlobalArgs, build_node};
+use crate::cli::GlobalArgs;
+use crate::cli::commands::wallets::WalletContext;
 use anyhow::anyhow;
 use clap::Parser;
-use rsnano_types::{Account, WalletId};
+use rsnano_types::Account;
 
 #[derive(Parser, PartialEq, Debug)]
 pub(crate) struct GetWalletRepresentativeArgs {
@@ -15,12 +16,8 @@ pub(crate) struct GetWalletRepresentativeArgs {
 
 impl GetWalletRepresentativeArgs {
     pub(crate) fn get_wallet_representative(&self, global_args: GlobalArgs) -> anyhow::Result<()> {
-        let node = build_node(&global_args)?;
-        let wallet_id =
-            WalletId::decode_hex(&self.wallet).ok_or_else(|| anyhow!("Invalid wallet id"))?;
-        let password = self.password.clone().unwrap_or_default();
-
-        node.wallets.ensure_wallet_is_unlocked(wallet_id, &password);
+        let context = WalletContext::from_args(&global_args, &self.wallet, &self.password)?;
+        let (node, wallet_id) = context.into_parts();
 
         let representative = node
             .wallets

--- a/main/src/cli/commands/wallets/import_keys.rs
+++ b/main/src/cli/commands/wallets/import_keys.rs
@@ -5,6 +5,7 @@ use clap::Parser;
 
 use rsnano_types::WalletId;
 
+use crate::cli::commands::wallets::WalletContext;
 use crate::cli::{GlobalArgs, build_node};
 
 #[derive(Parser, PartialEq, Debug)]
@@ -36,20 +37,20 @@ impl ImportKeysArgs {
             WalletId::decode_hex(&self.wallet).ok_or_else(|| anyhow!("Invalid wallet id"))?;
         let password = self.password.clone().unwrap_or_default();
 
-        node.wallets.ensure_wallet_is_unlocked(wallet_id, &password);
-
         if node.wallets.wallet_exists(&wallet_id) {
-            let valid = node.wallets.ensure_wallet_is_unlocked(wallet_id, &password);
-            if valid {
-                node.wallets
-                    .import_replace(wallet_id, &contents, &password)?
-            } else {
-                eprintln!(
-                    "Invalid password for wallet {}. New wallet should have empty (default) password or passwords for new wallet & json file should match",
-                    wallet_id
-                );
-                return Err(anyhow!("Invalid arguments"));
-            }
+            let context = match WalletContext::from_existing(node, wallet_id, password.clone()) {
+                Ok(ctx) => ctx,
+                Err(_) => {
+                    eprintln!(
+                        "Invalid password for wallet {}. New wallet should have empty (default) password or passwords for new wallet & json file should match",
+                        wallet_id
+                    );
+                    return Err(anyhow!("Invalid arguments"));
+                }
+            };
+            let (node, wallet_id) = context.into_parts();
+            node.wallets
+                .import_replace(wallet_id, &contents, &password)?
         } else if !self.force {
             eprintln!("Wallet doesn't exist");
             return Err(anyhow!("Invalid arguments"));

--- a/main/src/cli/commands/wallets/mod.rs
+++ b/main/src/cli/commands/wallets/mod.rs
@@ -8,6 +8,7 @@ mod get_wallet_representative;
 mod import_keys;
 mod remove_account;
 mod set_wallet_representative;
+mod wallet_context;
 
 use crate::cli::{GlobalArgs, build_node};
 use add_private_key::AddPrivateKeyArgs;
@@ -23,6 +24,7 @@ use import_keys::ImportKeysArgs;
 use remove_account::RemoveAccountArgs;
 use rsnano_types::Account;
 use set_wallet_representative::SetWalletRepresentativeArgs;
+pub(crate) use wallet_context::WalletContext;
 
 #[derive(Parser, PartialEq, Debug)]
 pub(crate) struct WalletsCommand {

--- a/main/src/cli/commands/wallets/remove_account.rs
+++ b/main/src/cli/commands/wallets/remove_account.rs
@@ -1,7 +1,8 @@
-use crate::cli::{GlobalArgs, build_node};
+use crate::cli::GlobalArgs;
+use crate::cli::commands::wallets::WalletContext;
 use anyhow::anyhow;
 use clap::Parser;
-use rsnano_types::{Account, WalletId};
+use rsnano_types::Account;
 
 #[derive(Parser, PartialEq, Debug)]
 pub(crate) struct RemoveAccountArgs {
@@ -18,15 +19,11 @@ pub(crate) struct RemoveAccountArgs {
 
 impl RemoveAccountArgs {
     pub(crate) fn remove_account(&self, global_args: GlobalArgs) -> anyhow::Result<()> {
-        let node = build_node(&global_args)?;
-        let wallet_id =
-            WalletId::decode_hex(&self.wallet).ok_or_else(|| anyhow!("Invalid wallet id"))?;
-        let password = self.password.clone().unwrap_or_default();
+        let context = WalletContext::from_args(&global_args, &self.wallet, &self.password)?;
+        let (node, wallet_id) = context.into_parts();
         let account = Account::parse(&self.account)
             .ok_or_else(|| anyhow!("Invalid account"))?
             .into();
-
-        node.wallets.ensure_wallet_is_unlocked(wallet_id, &password);
 
         node.wallets
             .remove_key(&wallet_id, &account)

--- a/main/src/cli/commands/wallets/set_wallet_representative.rs
+++ b/main/src/cli/commands/wallets/set_wallet_representative.rs
@@ -1,7 +1,8 @@
-use crate::cli::{GlobalArgs, build_node};
+use crate::cli::GlobalArgs;
+use crate::cli::commands::wallets::WalletContext;
 use anyhow::anyhow;
 use clap::Parser;
-use rsnano_types::{Account, WalletId};
+use rsnano_types::Account;
 
 #[derive(Parser, PartialEq, Debug)]
 pub(crate) struct SetWalletRepresentativeArgs {
@@ -18,15 +19,11 @@ pub(crate) struct SetWalletRepresentativeArgs {
 
 impl SetWalletRepresentativeArgs {
     pub(crate) fn set_representative_wallet(&self, global_args: GlobalArgs) -> anyhow::Result<()> {
-        let node = build_node(&global_args)?;
-        let wallet_id =
-            WalletId::decode_hex(&self.wallet).ok_or_else(|| anyhow!("Invalid wallet id"))?;
+        let context = WalletContext::from_args(&global_args, &self.wallet, &self.password)?;
+        let (node, wallet_id) = context.into_parts();
         let representative = Account::parse(&self.account)
             .ok_or_else(|| anyhow!("Invalid account"))?
             .into();
-        let password = self.password.clone().unwrap_or_default();
-
-        node.wallets.ensure_wallet_is_unlocked(wallet_id, &password);
 
         node.wallets
             .set_representative(wallet_id, representative, false)

--- a/main/src/cli/commands/wallets/wallet_context.rs
+++ b/main/src/cli/commands/wallets/wallet_context.rs
@@ -21,7 +21,10 @@ impl WalletContext {
 
     pub(crate) fn new(node: Node, wallet: &str, password: String) -> Result<Self> {
         let wallet_id = WalletId::decode_hex(wallet).ok_or_else(|| anyhow!("Invalid wallet id"))?;
+        Self::from_existing(node, wallet_id, password)
+    }
 
+    pub(crate) fn from_existing(node: Node, wallet_id: WalletId, password: String) -> Result<Self> {
         if !node.wallets.wallet_exists(&wallet_id) {
             return Err(anyhow!("Wallet not found"));
         }

--- a/main/src/cli/commands/wallets/wallet_context.rs
+++ b/main/src/cli/commands/wallets/wallet_context.rs
@@ -1,0 +1,94 @@
+use crate::cli::{GlobalArgs, build_node};
+use anyhow::{Result, anyhow};
+use rsnano_node::Node;
+use rsnano_types::WalletId;
+
+/// Helper that guarantees the wallet exists and is unlocked before continuing.
+pub(crate) struct WalletContext {
+    node: Node,
+    wallet_id: WalletId,
+}
+
+impl WalletContext {
+    pub(crate) fn from_args(
+        global_args: &GlobalArgs,
+        wallet: &str,
+        password: &Option<String>,
+    ) -> Result<Self> {
+        let node = build_node(global_args)?;
+        Self::new(node, wallet, password.clone().unwrap_or_default())
+    }
+
+    pub(crate) fn new(node: Node, wallet: &str, password: String) -> Result<Self> {
+        let wallet_id = WalletId::decode_hex(wallet).ok_or_else(|| anyhow!("Invalid wallet id"))?;
+
+        if !node.wallets.wallet_exists(&wallet_id) {
+            return Err(anyhow!("Wallet not found"));
+        }
+
+        if !node.wallets.ensure_wallet_is_unlocked(wallet_id, &password) {
+            return Err(anyhow!("Invalid wallet password"));
+        }
+
+        Ok(Self { node, wallet_id })
+    }
+
+    pub(crate) fn into_parts(self) -> (Node, WalletId) {
+        (self.node, self.wallet_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rsnano_node::Node;
+
+    fn create_wallet(node: &Node, password: &str) -> WalletId {
+        let wallet_id = WalletId::random();
+        node.wallets.create(wallet_id);
+        node.wallets.rekey(&wallet_id, password).unwrap();
+        wallet_id
+    }
+
+    #[test]
+    fn fails_for_invalid_wallet_id() {
+        let node = Node::new_null();
+        let err = match WalletContext::new(node, "xyz", String::new()) {
+            Ok(_) => panic!("expected invalid wallet id"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("Invalid wallet id"));
+    }
+
+    #[test]
+    fn fails_when_wallet_missing() {
+        let node = Node::new_null();
+        let missing_wallet_hex = WalletId::random().encode_hex();
+        let err = match WalletContext::new(node, &missing_wallet_hex, String::new()) {
+            Ok(_) => panic!("expected missing wallet"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("Wallet not found"));
+    }
+
+    #[test]
+    fn fails_when_password_is_wrong() {
+        let node = Node::new_null();
+        let wallet_id = create_wallet(&node, "correct-password");
+        node.wallets.lock(&wallet_id).unwrap();
+        let err = match WalletContext::new(node, &wallet_id.encode_hex(), "bad".into()) {
+            Ok(_) => panic!("expected invalid password"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("Invalid wallet password"));
+    }
+
+    #[test]
+    fn returns_context_when_unlocked() {
+        let node = Node::new_null();
+        let wallet_id = create_wallet(&node, "pw");
+        let context = WalletContext::new(node, &wallet_id.encode_hex(), "pw".into()).unwrap();
+        let (_, returned_wallet_id) = context.into_parts();
+        assert_eq!(returned_wallet_id, wallet_id);
+    }
+}


### PR DESCRIPTION
**Wallet CLI refactor and guardrails**

- Added WalletContext helper to centralize wallet id parsing, existence check, and unlock validation; all wallet subcommands now use it (create/add/remove/change seed/rep, decrypt, destroy, get/set rep, import). This removes per-command boilerplate and enforces consistent error handling.

- WalletContext includes tests for invalid id, missing wallet, wrong password, and unlocked success. import_keys now uses the helper for existing wallets while preserving its password-error message; create_wallet/list/clear_send_ids stay as-is because they create or don’t require unlock.

- **Behavior change**: commands now fail fast with clear errors when the wallet is missing or the password is wrong (some commands previously proceeded or ignored the unlock result). This aligns with “fail fast” mentality.