### PR TITLE
Refactor(tcp): Improve port selection logic for testcases

### DIFF
--- a/nullables/tcp/src/lib.rs
+++ b/nullables/tcp/src/lib.rs
@@ -2,20 +2,23 @@ mod tcp_socket;
 mod tcp_stream;
 mod tcp_stream_factory;
 
-use std::sync::atomic::{AtomicU16, Ordering};
+use std::net::TcpListener;
 pub use tcp_socket::*;
 pub use tcp_stream::TcpStream;
 pub use tcp_stream_factory::TcpStreamFactory;
 
-static START_PORT: AtomicU16 = AtomicU16::new(1025);
-
 pub fn get_available_port() -> u16 {
-    let start = START_PORT.fetch_add(1, Ordering::SeqCst);
-    (start..65535)
-        .find(|port| is_port_available(*port))
-        .expect("Could not find an available port")
+    // Let the OS pick an ephemeral port on loopback to minimize collisions and
+    // avoid hardcoded ranges. Try IPv6 first (covers dual-stack), fall back to
+    // IPv4 if needed.
+    pick_ephemeral_port(["::1", "127.0.0.1"]).expect("Could not find an available port")
 }
 
-fn is_port_available(port: u16) -> bool {
-    std::net::TcpListener::bind(("127.0.0.1", port)).is_ok()
+fn pick_ephemeral_port<const N: usize>(hosts: [&str; N]) -> Option<u16> {
+    hosts.iter().find_map(|host| {
+        TcpListener::bind((*host, 0))
+            .ok()
+            .and_then(|listener| listener.local_addr().ok())
+            .map(|addr| addr.port())
+    })
 }


### PR DESCRIPTION
This fixes most testcase issues on macOS that are related to port binding...

- Remove hardcoded port range and atomic counter.
- Use the operating system's ephemeral port allocation for increased reliability and reduced collisions.
- Prioritize IPv6 loopback for dual-stack compatibility, falling back to IPv4 if necessary.