### PR TITLE
Fix Docker entrypoint data path permissions

### DIFF
--- a/tools/scripts/docker/banano/entrypoint.sh
+++ b/tools/scripts/docker/banano/entrypoint.sh
@@ -2,7 +2,38 @@
 set -e
 
 DATA_DIR=/home/bananocurrency/Banano
+APP_DIR="$DATA_DIR"
+NEXT_ARG_IS_DATA_PATH=false
 
-chown -R bananocurrency:bananocurrency "$DATA_DIR"
+for arg in "$@"; do
+    if [ "$NEXT_ARG_IS_DATA_PATH" = true ]; then
+        APP_DIR="$arg"
+        NEXT_ARG_IS_DATA_PATH=false
+        continue
+    fi
+
+    case "$arg" in
+        --data-path=*|--data_path=*)
+            APP_DIR="${arg#*=}"
+            ;;
+        --data-path|--data_path)
+            NEXT_ARG_IS_DATA_PATH=true
+            ;;
+    esac
+done
+
+mkdir -p "$DATA_DIR" "$APP_DIR"
+
+APP_PARENT="$(dirname "$APP_DIR")"
+case "$APP_PARENT" in
+    /root|/home/bananocurrency)
+        # V2.0 Docker images ran as root, so existing setups may keep data under /root.
+        chown bananocurrency:bananocurrency "$APP_PARENT"
+        ;;
+esac
+
+chown -R bananocurrency:bananocurrency "$DATA_DIR" "$APP_DIR"
+
+export HOME=/home/bananocurrency
 
 exec gosu bananocurrency /usr/bin/rsban "$@"

--- a/tools/scripts/docker/nano/entrypoint.sh
+++ b/tools/scripts/docker/nano/entrypoint.sh
@@ -2,7 +2,38 @@
 set -e
 
 DATA_DIR=/home/nanocurrency/Nano
+APP_DIR="$DATA_DIR"
+NEXT_ARG_IS_DATA_PATH=false
 
-chown -R nanocurrency:nanocurrency "$DATA_DIR"
+for arg in "$@"; do
+    if [ "$NEXT_ARG_IS_DATA_PATH" = true ]; then
+        APP_DIR="$arg"
+        NEXT_ARG_IS_DATA_PATH=false
+        continue
+    fi
+
+    case "$arg" in
+        --data-path=*|--data_path=*)
+            APP_DIR="${arg#*=}"
+            ;;
+        --data-path|--data_path)
+            NEXT_ARG_IS_DATA_PATH=true
+            ;;
+    esac
+done
+
+mkdir -p "$DATA_DIR" "$APP_DIR"
+
+APP_PARENT="$(dirname "$APP_DIR")"
+case "$APP_PARENT" in
+    /root|/home/nanocurrency)
+        # V2.0 Docker images ran as root, so existing setups may keep data under /root.
+        chown nanocurrency:nanocurrency "$APP_PARENT"
+        ;;
+esac
+
+chown -R nanocurrency:nanocurrency "$DATA_DIR" "$APP_DIR"
+
+export HOME=/home/nanocurrency
 
 exec gosu nanocurrency /usr/bin/rsnano "$@"


### PR DESCRIPTION
  V2.0 Docker images ran the node as root with `/root` as the working directory,
  so existing Docker setups may keep node data under paths such as
  `/root/NanoTest`.

  The current Docker image drops privileges to the `nanocurrency` user before
  starting the daemon. When an existing setup passes an explicit data path under
  `/root`, the node can no longer create or write files such as
  `node_id_private.key`.

  Update the Docker entrypoints to detect `--data-path` / `--data_path`, create
  and chown the selected app directory, and preserve access to known compatible
  container data parents before switching users.

  This keeps the daemon non-root while preserving compatibility with V2.0-style
  Docker data paths.

  Validation:

  Validated against the V2.0 Dockerfile behavior: V2.0 used `WORKDIR /root`,
  `USER root`, and directly executed `rsnano_node`.
  Also smoke-tested the new image with a bind-mounted `/root` and
  `--data-path=/root/NanoTest`.